### PR TITLE
FIX Radio $inline

### DIFF
--- a/src/Radio.php
+++ b/src/Radio.php
@@ -34,7 +34,7 @@ class Radio extends Select
      *
      * @var bool
      */
-    protected bool $inline = false;
+    public $inline = false;
 
     /**
      * Gutters between items.


### PR DESCRIPTION
This problem started showing up for me in Laravel Nova 4.26.1

```
Access level to NormanHuth\\NovaRadioField\\Radio::$inline must be public (as in class Laravel\\Nova\\Fields\\Field)
```